### PR TITLE
Assignment 1: explicitly forbid /dev/null only

### DIFF
--- a/assignments/01-cli-investigative.md
+++ b/assignments/01-cli-investigative.md
@@ -49,9 +49,9 @@ syllabus for an example) with each:
 5. How can you make `cat` number each line in a file? (Answer this question
    without referencing the internet, please!)
 6. Files inside the special filesystem `/dev/` are used to communicate with the
-   Linux kernel. Choose a file that looks interesting inside `/dev/` (but not
-   one that we have already talked about in class already) and tell us what
-   it's for. You are free to use Google or any other internet or printed
+   Linux kernel. Choose a file that looks interesting inside `/dev/` and tell
+   us what it's for. Please don't choose `/dev/null`, as we will discuss that
+   in lecture. You are free to use Google or any other internet or printed
    resource, but cite your source.
 7. `/etc/` is a standard directory on Linux that contains system configuration
    files. Although file extensions (like `.txt` and `.jpg`) have no intrinsic


### PR DESCRIPTION
We may not have mentioned `/dev/null` in lecture by the time students read the assignment, so let's explicitly tell them that it's coming. This also means we won't accidentally punish students who do the assignment early if we mention something else from `/dev/` when answering a question in lecture.